### PR TITLE
Add bookmark resume functionality

### DIFF
--- a/.agent-os/product/roadmap.md
+++ b/.agent-os/product/roadmap.md
@@ -20,7 +20,7 @@
 - [x] Decision point interface - Interactive choice buttons with branching logic `M`
 - [x] Audio playback system - Text-to-speech with play/pause controls and premium voice selection `M`
 - [x] Progress tracking - Track completed paths, current position, and story completion percentage `S`
-- [ ] Bookmark functionality - Save and restore reading position within stories `S`
+- [x] Bookmark functionality - Auto-resume with "continuing where you left off" notice `S`
 - [ ] First complete story - "Little Red Riding Hood" with 3-4 branching paths fully authored and narrated `XL`
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ StoryPath brings timeless public domain stories to life with branching narrative
 - "Authentic path" indicators showing choices that follow the original story
 - Story restart from any ending
 - VoiceOver accessibility support
+- Text-to-speech narration with play/pause controls
+- Progress tracking with completion percentage
+- Auto-resume from bookmarked position
 
 ## Planned Features
 
-- Audio narration for all story paths
-- Progress tracking and bookmarking
 - Story library with multiple tales
 - AI-generated illustrations
 - In-app purchases for additional stories
@@ -40,7 +41,7 @@ choose-your-own-story/
 │   │   ├── Models/         # Story, StorySegment, StoryChoice
 │   │   ├── Views/          # StoryReadingView
 │   │   ├── ViewModels/     # StoryReadingViewModel
-│   │   ├── Services/       # StoryLoader, StoryRepository
+│   │   ├── Services/       # StoryLoader, StoryRepository, ProgressService, AudioService
 │   │   └── Resources/      # Story JSON content
 │   ├── StoryPathTests/     # Unit tests
 │   └── StoryPath.xcodeproj

--- a/StoryPath/StoryPath/Views/StoryReadingView.swift
+++ b/StoryPath/StoryPath/Views/StoryReadingView.swift
@@ -78,18 +78,46 @@ struct StoryReadingView: View {
         .padding()
     }
 
+    private var resumeBanner: some View {
+        HStack {
+            Image(systemName: "bookmark.fill")
+                .foregroundStyle(Color(red: 0.83, green: 0.66, blue: 0.29))
+            Text("Continuing where you left off")
+                .font(.subheadline)
+            Spacer()
+            Button("Start Over") {
+                viewModel.restartStory()
+                viewModel.dismissBookmarkNotice()
+            }
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(Color(red: 0.83, green: 0.66, blue: 0.29))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(red: 0.83, green: 0.66, blue: 0.29).opacity(0.15))
+        .onTapGesture {
+            viewModel.dismissBookmarkNotice()
+        }
+    }
+
     private func segmentContentView(_ segment: StorySegment) -> some View {
         ZStack(alignment: .bottomTrailing) {
             ScrollViewReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 24) {
+                        // Resume banner
+                        if viewModel.didResumeFromBookmark {
+                            resumeBanner
+                                .id("top")
+                        }
+
                         // Story text
                         Text(segment.text)
                             .font(.custom("Georgia", size: 18))
                             .lineSpacing(6)
                             .padding(.horizontal, 20)
-                            .padding(.top, 20)
-                            .id("top")
+                            .padding(.top, viewModel.didResumeFromBookmark ? 0 : 20)
+                            .id(viewModel.didResumeFromBookmark ? "text" : "top")
 
                         // Choices or ending
                         if segment.isEnding {


### PR DESCRIPTION
## Summary
- Auto-resume from bookmarked position with "Continuing where you left off" banner
- "Start Over" option to restart from beginning
- Banner dismisses on navigation or restart
- Updated README and roadmap

## Test plan
- [x] Navigate through story, close app, reopen - should show resume banner
- [x] Tap "Start Over" to restart from beginning
- [x] Make a choice - banner dismisses
- [x] All 28 tests passing