### PR TITLE
Force light mode until dark mode is implemented

### DIFF
--- a/StoryPath/StoryPath/StoryPathApp.swift
+++ b/StoryPath/StoryPath/StoryPathApp.swift
@@ -12,6 +12,7 @@ struct StoryPathApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(.light)
         }
         .windowResizability(.contentSize)
     }


### PR DESCRIPTION
Fixes unreadable text when device is in dark mode by forcing light color scheme app-wide.