### PR TITLE
Add info button to pull-to-reveal nav bar

### DIFF
--- a/StoryPath/StoryPath/Views/StoryDetailView.swift
+++ b/StoryPath/StoryPath/Views/StoryDetailView.swift
@@ -14,6 +14,7 @@ struct StoryDetailView: View {
     let story: Story
     let progress: UserProgress?
     var onStartReading: ((String) -> Void)?
+    var showActionButton: Bool = true
 
     @State private var audioService = AudioService()
 
@@ -90,7 +91,9 @@ struct StoryDetailView: View {
                 if hasProvenance {
                     provenanceSection
                 }
-                actionButton
+                if showActionButton {
+                    actionButton
+                }
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 40)

--- a/StoryPath/StoryPath/Views/StoryReadingView.swift
+++ b/StoryPath/StoryPath/Views/StoryReadingView.swift
@@ -21,6 +21,7 @@ struct StoryReadingView: View {
     @State private var fullscreenImage: String?
     @State private var showNavBar = false
     @State private var showPullHint = false
+    @State private var showStoryDetail = false
     @State private var showResumeIndicator = false
     @State private var hasShownResumeIndicator = false
     @State private var resumeIndicatorTask: Task<Void, Never>?
@@ -107,6 +108,24 @@ struct StoryReadingView: View {
                 viewModel.speakCurrentSegment()
             }
         }
+        .sheet(isPresented: $showStoryDetail) {
+            if let story = viewModel.story {
+                NavigationStack {
+                    StoryDetailView(
+                        story: story,
+                        progress: viewModel.progress,
+                        showActionButton: false
+                    )
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") {
+                                showStoryDetail = false
+                            }
+                        }
+                    }
+                }
+            }
+        }
         #if os(iOS)
         .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
             let newOrientation = UIDevice.current.orientation
@@ -154,7 +173,18 @@ struct StoryReadingView: View {
 
             Spacer()
 
+            // Story info button
+            Button {
+                showStoryDetail = true
+            } label: {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 22))
+                    .foregroundStyle(accentColor)
+            }
+            .accessibilityLabel("Story information")
+
             audioControlButton
+                .padding(.leading, 16)
 
             // Hide menu button
             Button {


### PR DESCRIPTION
## Summary
- Add info button to story navigation bar in reading view
- Tapping presents StoryDetailView as a sheet
- Hide the action button when viewing from within reading view (already reading)

## Test plan
- [x] Open a story, pull down to reveal nav bar
- [x] Tap info button - story detail sheet appears
- [x] Verify "Start Reading" button is not shown
- [x] Tap Done to dismiss

Closes #93